### PR TITLE
btoa data cleaning before base64_decode

### DIFF
--- a/index.php
+++ b/index.php
@@ -816,7 +816,7 @@ class Pi {
       phpinfo();
       exit;
     } else if(!empty($_POST['code-box']) && isset($_POST['operation'])) {
-      $code = base64_decode($_POST['code-box']);
+      $code = base64_decode( strtr( $_POST['code-box'], ' ', '+')) ;
       $operation = $_POST['operation'];
       ob_start();
       switch ($operation) {


### PR DESCRIPTION
Remove garbage during btoa encoding process, which occurs occasionally. 

Source: https://stackoverflow.com/a/44344774